### PR TITLE
Search through nested files (input, import, include) for citations

### DIFF
--- a/bibfish/__init__.py
+++ b/bibfish/__init__.py
@@ -151,9 +151,9 @@ def cli():
         "--cc",
         action="store",
         type=str,
-        default="citet,citep",
+        default="cite,citet,citep",
         dest="cite_commands",
-        help="Cite commands separated by commas (default: 'citet,citep')",
+        help="Cite commands separated by commas (default: 'cite,citet,citep')",
     )
     parser.add_argument(
         "-f",

--- a/bibfish/__init__.py
+++ b/bibfish/__init__.py
@@ -20,6 +20,10 @@ def extract_citekeys(manuscript_file, cite_commands):
     with open(manuscript_file, "r") as file:
         manuscript = file.read()
     citekeys = []
+    try:
+        manuscript = manuscript.split(r"\begin{document}")[1]
+    except IndexError:
+        pass
     for nestfile in find_imported_files(manuscript):
         try:
             citekeys += extract_citekeys(nestfile, cite_commands)


### PR DESCRIPTION
This attempts to solve the issue opened in ' Multiple input tex files #1 '. extract_citekeys will be called recursively on any file that has been imported and has either a .tex extension, or no extension.