### PR TITLE
Crossref and other minor changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.6"
 dependencies = [
-  "bibtexparser>=1.4.1",
+  "bibtexparser==1.4.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
Added support for crossref.

In addition, fixed bibtexparser to version 1.4.1, because the upcoming version 2.0 will not be compatible.

The second commit adds a --drop-fields argument for filtering of the saved database. (I use it to remove Jabref-specific fields like comments, abstract, files, etc.