### PR TITLE
Commented Lines in manuscript file

### DIFF
--- a/bibfish/__init__.py
+++ b/bibfish/__init__.py
@@ -7,7 +7,6 @@ import bibtexparser
 from bibtexparser.bibdatabase import BibDatabase
 
 
-
 try:
     from ._version import __version__
 except ImportError:

--- a/bibfish/__init__.py
+++ b/bibfish/__init__.py
@@ -7,6 +7,7 @@ import bibtexparser
 from bibtexparser.bibdatabase import BibDatabase
 
 
+
 try:
     from ._version import __version__
 except ImportError:
@@ -22,7 +23,14 @@ def extract_citekeys(manuscript_file: str, cite_commands: list) -> list:
     if len(cite_commands) == 0:
         return []
     with open(manuscript_file, "r") as file:
-        manuscript = file.read()
+        full_manuscript = file.read()
+
+    uncommented_lines = []
+    for line in full_manuscript.splitlines():
+        if not line.strip().startswith("%"):
+            uncommented_lines.append(line)
+    manuscript = "\n".join(uncommented_lines)
+
     citekeys = []
     try:
         manuscript = manuscript.split(r"\begin{document}")[1]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+"""This module has unit tests for the bibfish __init__ functions."""
+
+# Copyright 2023-2024, bibfish developers
+#
+# Licensed under the MIT License, see the top-level LICENSE
+# file for more information.
+
+from textwrap import dedent
+import unittest
+from unittest.mock import mock_open, patch
+
+from bibtexparser.bibdatabase import BibDatabase
+
+import bibfish
+
+
+class TestDOI(unittest.TestCase):
+    def test_get_short_doi(self):
+        doi = "10.3847/PSJ/ac09e9"
+        short_doi = "10/js88"
+
+        self.assertEqual(short_doi, bibfish.get_short_doi(doi))
+
+
+class TestBibtexParser(unittest.TestCase):
+
+    def test_update_bibdatabase(self):
+        entries1 = [
+            {"ID": "one", "ENTRYTYPE": "book"},
+            {"ID": "two", "ENTRYTYPE": "article"},
+        ]
+        entries2 = [
+            {"ID": "three", "ENTRYTYPE": "book"},
+            {"ID": "four", "ENTRYTYPE": "article"},
+        ]
+
+        db1 = BibDatabase()
+        db1.entries = entries1
+
+        db2 = BibDatabase()
+        db2.entries = entries2
+
+        new_db = bibfish.update_bibdatabase(db1, db2)
+
+        self.assertEqual(new_db.entries, entries1 + entries2)
+
+class TestCitekeys(unittest.TestCase):
+
+    def test_extract_citekeys(self):
+
+        with patch(
+            "bibfish.open",
+            mock_open(read_data=dedent(
+                r"""\
+                \documentclass{book}
+                % If there are commented lines, which contain
+                % \begin{document}
+                % but no citation commands, we want to make sure
+                % only the uncommented lines count.
+                \begin{document}
+                This line has a citation \citep{ref1}.
+                This one doesn't.
+                """
+            ))
+        ):
+            citekeys = bibfish.extract_citekeys("dummy.tex", ["cite", "citet", "citep"])
+            self.assertEqual(len(citekeys), 1)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -45,14 +45,16 @@ class TestBibtexParser(unittest.TestCase):
 
         self.assertEqual(new_db.entries, entries1 + entries2)
 
+
 class TestCitekeys(unittest.TestCase):
 
     def test_extract_citekeys(self):
 
         with patch(
             "bibfish.open",
-            mock_open(read_data=dedent(
-                r"""\
+            mock_open(
+                read_data=dedent(
+                    r"""\
                 \documentclass{book}
                 % If there are commented lines, which contain
                 % \begin{document}
@@ -62,7 +64,8 @@ class TestCitekeys(unittest.TestCase):
                 This line has a citation \citep{ref1}.
                 This one doesn't.
                 """
-            ))
+                )
+            ),
         ):
             citekeys = bibfish.extract_citekeys("dummy.tex", ["cite", "citet", "citep"])
             self.assertEqual(len(citekeys), 1)


### PR DESCRIPTION
I discovered that if I had a commented out `\begin{document}` before the uncommented `\begin{document}` the citations in the main document were not extracted (because of the `split()`).

This PR has bibfish ignore any percent-commented-out lines before doing its check for citations.  I also added a test file that I had forgotten to do when I PRed the BibtexParser stuff.